### PR TITLE
fix Data instance

### DIFF
--- a/src/Data/Fix.hs
+++ b/src/Data/Fix.hs
@@ -2,7 +2,9 @@
         FlexibleContexts, 
         UndecidableInstances,
         TypeSynonymInstances,
-        DeriveGeneric #-}
+        DeriveGeneric,
+        DeriveDataTypeable,
+        StandaloneDeriving #-}
 -- | Fix-point type. It allows to define generic recurion schemes.
 --
 -- > Fix f = f (Fix f)
@@ -59,7 +61,7 @@ import Data.Traversable
 
 -- | A fix-point type. 
 newtype Fix f = Fix { unFix :: f (Fix f) } deriving (Generic, Typeable)
-instance Typeable f => Data (Fix f)
+deriving instance (Typeable f, Data (f (Fix f))) => Data (Fix f)
 
 -- standard instances 
 


### PR DESCRIPTION
Oops, I think I didn't get that last one quite right - sorry!

I was playing around with some orphan instances (so I could use `uniplate` on an AST that uses `Fix`), and I though I got my changes right the first time around, but after squinting a little harder, I realized that `uniplate` wasn't traversing the AST at all. Of course, I forgot to derive the instance of `Data (Fix f)`.


Things appear to be working with this change.