### PR TITLE
Tighten lower-bound on base

### DIFF
--- a/data-fix.cabal
+++ b/data-fix.cabal
@@ -1,6 +1,6 @@
 Name:            data-fix
 Version:         0.0.4
-Cabal-Version:   >= 1.6
+Cabal-Version:   >= 1.10
 License:         BSD3
 License-file:    LICENSE
 Author:          Anton Kholomiov
@@ -24,7 +24,8 @@ Source-repository head
     Location: https://github.com/anton-k/data-fix
 
 Library
-  Build-depends: base >= 4, base < 5
+  Default-Language: Haskell2010
+  Build-depends: base >= 4.7, base < 5
   Hs-source-dirs: src/
 
   ghc-options: -Wall


### PR DESCRIPTION
The compile failure below occurs with GHC 7.6 / base-4.6; consequently setting tighter bound `base >= 4.7` keeps the cabal solver from running into that compile failure.

```
In order, the following will be built (use -v for more details):
 - data-fix-0.0.4 {data-fix-0.0.4-inplace} (lib:data-fix) (first run)
Configuring data-fix-0.0.4...
Preprocessing library data-fix-0.0.4...
[1 of 1] Compiling Data.Fix         ( src/Data/Fix.hs, /tmp/matrix-worker/1490780578/dist-newstyle/build/x86_64-linux/ghc-7.6.3/data-fix-0.0.4/build/Data/Fix.o )

src/Data/Fix.hs:64:63:
    Can't make a derived instance of `Typeable (Fix f)':
      `Fix' must only have arguments of kind `*'
    In the newtype declaration for `Fix'

src/Data/Fix.hs:65:38:
    `f' is applied to too many type arguments
    In the stand-alone deriving instance for
      `(Typeable f, Data (f (Fix f))) => Data (Fix f)'

```

This also updates the `cabal-version` to the currently recommended version (as it avoids modern cabal versions to fallback into legacy mode)