### PR TITLE
bump base upper bound to <4.18

### DIFF
--- a/data-fix.cabal
+++ b/data-fix.cabal
@@ -57,7 +57,7 @@ library
       -Wredundant-constraints -Widentities -Wmissing-export-lists
 
   build-depends:
-      base      >=4.4     && <4.17
+      base      >=4.4     && <4.18
     , deepseq   >=1.3.0.0 && <1.5
     , hashable  >=1.2.7.0 && <1.5
 


### PR DESCRIPTION
This builds with

```
cabal build -w ghc-9.4.1 --allow-newer='hashable:*'
```