### PR TITLE
Add newtype around Fix with Functor and Traversable instances

### DIFF
--- a/data-fix.cabal
+++ b/data-fix.cabal
@@ -58,7 +58,7 @@ library
       -Wredundant-constraints -Widentities -Wmissing-export-lists
 
   build-depends:
-      base      >=4.4     && <4.18
+      base      >=4.10    && <4.18
     , deepseq   >=1.3.0.0 && <1.5
     , hashable  >=1.2.7.0 && <1.5
 


### PR DESCRIPTION
If base Functor is actually BiFunctor with one parameter applied, resulting Fix
can have Functor instance too (GHC can't derive it automatically, unfortunately).

In same vein, if base functor is partial application of Bitraversable,
resulting Fix admits Traversable instance.

Some background. I was writing parser for some language in which are represented by numbers, and mapping from number to something useful comes much later, and it is quite inconvenient to get mapping before parsing language. Think it this way:

Here is expression:
```
($1 + 2) * $3
```

which translates to following base functor and following expression type:

```
data ExprF v a = Add a a | Mul a a | Const Int | Var v
newtype Expr v = Expr (Fix (ExprF v))
```
So parsing step yields `Expr Int` and at some point later I want to convert it into `Expr Text` (where Text is name of variable). 
Just bear with me. I need function:

```
foo :: Map Int Text -> Expr Int -> Maybe (Expr Text)
foo env e = sequenceA $ fmap (Map.lookup env) e
```

Except Expr is neither Functor nor Traversable. In my specific case I wrote instances manually, but after that I realized that
given right constraints on base functor, these instances can be written generically. Hence the patch.

Note that it raises requirements on `base` (or, alternatively, requires dependency on `bifunctors`). 
